### PR TITLE
Fix NPM publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 # 2.3.2 (2017-07-10)
 
-Upgrade Ember CLI version from 2.11.0 to 2.12.3
+* Upgrade Ember CLI version from 2.11.0 to 2.12.3
 
 
 # 2.3.1 (2017-05-12)


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Text change to trigger a new NPM release since `3.0.0` says its published on npmjs.org but is not found when doing an `npm install`